### PR TITLE
fix: dynamic workpsace permissions fix

### DIFF
--- a/cmd/project-workspace-operator/app/run.go
+++ b/cmd/project-workspace-operator/app/run.go
@@ -318,7 +318,7 @@ func (o *RunOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("unable to get cluster request for onboarding cluster: %w", err)
 	}
 
-	cfgCtrl, err := sharedconfig.NewPWOConfigController(o.ProviderName, o.PlatformCluster, onboardingCluster, cr.Status.Cluster, nil, podNamespace)
+	cfgCtrl, err := sharedconfig.NewPWOConfigController(o.ProviderName, o.PlatformCluster, onboardingCluster, cr.Status.Cluster, nil, podNamespace, rbacSetup)
 	if err != nil {
 		return fmt.Errorf("unable to create ProjectWorkspaceConfig controller: %w", err)
 	}

--- a/internal/controller/config/controller.go
+++ b/internal/controller/config/controller.go
@@ -46,6 +46,14 @@ const (
 	ClusterIDOnboardingDynamic = "onboarding-dynamic"
 )
 
+// ClusterRoleUpdater is implemented by core.RBACSetup and allows the config controller to
+// update the workspace/project ClusterRoles on the onboarding cluster whenever the set of
+// registered ServiceProviders changes, without creating an import cycle.
+type ClusterRoleUpdater interface {
+	CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx context.Context, dynamicRules map[string][]rbacv1.PolicyRule) error
+	CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx context.Context, dynamicRules map[string][]rbacv1.PolicyRule) error
+}
+
 var (
 	BuiltinResourcesBlockingProjectDeletion = []DeletionBlockingResource{
 		{
@@ -90,6 +98,7 @@ type PWOConfigController struct {
 	rec                           record.EventRecorder
 	OnboardingClusterAccessStatic *clusters.Cluster
 	DiscoveryService              discovery.DiscoveryInterface
+	rbacSetup                     ClusterRoleUpdater // used to update ClusterRoles when ServiceProviders change
 
 	// The lock needs to be held when reading or writing any of the fields below.
 	lock                               *sync.RWMutex
@@ -149,7 +158,7 @@ func (l APIGroupsWithResourcesList) Append(elems ...APIGroupsWithResources) APIG
 // - It reconciles the OnboardingCluster AccessRequests for the project and workspace controllers to ensure they can always fetch the the resources that are supposed to block deletion.
 //
 // Note that this is a pure v2 controller. It does neither work for v1, nor is it required, because in v1 all of this information is statically read from a file.
-func NewPWOConfigController(providerName string, platformCluster *clusters.Cluster, onboardingClusterStatic *clusters.Cluster, onboardingClusterRef *commonapi.ObjectReference, rec record.EventRecorder, podNamespace string) (*PWOConfigController, error) {
+func NewPWOConfigController(providerName string, platformCluster *clusters.Cluster, onboardingClusterStatic *clusters.Cluster, onboardingClusterRef *commonapi.ObjectReference, rec record.EventRecorder, podNamespace string, rbacSetup ClusterRoleUpdater) (*PWOConfigController, error) {
 	scheme := install.InstallOperatorAPIsOnboarding(runtime.NewScheme())
 	obRef := advanced.StaticReferenceGenerator(onboardingClusterRef)
 	var ds discovery.DiscoveryInterface
@@ -165,6 +174,7 @@ func NewPWOConfigController(providerName string, platformCluster *clusters.Clust
 		platformCluster:               platformCluster,
 		OnboardingClusterAccessStatic: onboardingClusterStatic,
 		DiscoveryService:              ds,
+		rbacSetup:                     rbacSetup,
 		Car: advanced.NewClusterAccessReconciler(platformCluster.Client(), ControllerName).
 			Register(advanced.ExistingCluster(ClusterIDOnboardingDynamic, "obdyn", obRef).WithScheme(scheme).WithNamespaceGenerator(func(_ reconcile.Request, _ ...any) (string, error) { return podNamespace, nil }).Build()),
 		rec:                                rec,
@@ -459,6 +469,39 @@ func (c *PWOConfigController) reconcile(ctx context.Context, req reconcile.Reque
 					log.Debug(fmt.Sprintf("%s permissions for role '%s'", k, roleID), "permissions", string(permBytes))
 				}
 			}
+		}
+	}
+
+	// Re-reconcile the global workspace and project ClusterRoles on the onboarding cluster
+	// to pick up resources advertised by newly registered (or removed) ServiceProviders.
+	if c.rbacSetup != nil {
+		workspaceDynamicRules := map[string][]rbacv1.PolicyRule{}
+		for _, roleID := range []string{AdminRole, ViewerRole} {
+			rules, err := c.workspacePermissionsForRoleInternal(roleID)
+			if err != nil {
+				return cfg, reconcile.Result{}, fmt.Errorf("failed to compute workspace permissions for role %s: %w", roleID, err)
+			}
+			workspaceDynamicRules[roleID] = rules
+		}
+		if err := c.rbacSetup.CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx, workspaceDynamicRules); err != nil {
+			return cfg, reconcile.Result{}, fmt.Errorf("failed to update workspace ClusterRoles after ServiceProvider change: %w", err)
+		}
+		apiGroups := make([]string, 0, len(c.permissibleWorkspaceResources))
+		for _, agr := range c.permissibleWorkspaceResources {
+			apiGroups = append(apiGroups, agr.APIGroups...)
+		}
+		log.Info("Updated workspace ClusterRoles from ServiceProvider resources", "apiGroups", apiGroups)
+
+		projectDynamicRules := map[string][]rbacv1.PolicyRule{}
+		for _, roleID := range []string{AdminRole, ViewerRole} {
+			rules, err := c.projectPermissionsForRoleInternal(roleID)
+			if err != nil {
+				return cfg, reconcile.Result{}, fmt.Errorf("failed to compute project permissions for role %s: %w", roleID, err)
+			}
+			projectDynamicRules[roleID] = rules
+		}
+		if err := c.rbacSetup.CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx, projectDynamicRules); err != nil {
+			return cfg, reconcile.Result{}, fmt.Errorf("failed to update project ClusterRoles after ServiceProvider change: %w", err)
 		}
 	}
 

--- a/internal/controller/config/controller_test.go
+++ b/internal/controller/config/controller_test.go
@@ -7,12 +7,14 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +32,7 @@ import (
 	pwov1alpha1 "github.com/openmcp-project/project-workspace-operator/api/core/v1alpha1"
 	"github.com/openmcp-project/project-workspace-operator/api/install"
 	sharedconfig "github.com/openmcp-project/project-workspace-operator/internal/controller/config"
+	"github.com/openmcp-project/project-workspace-operator/internal/controller/core"
 )
 
 const (
@@ -125,7 +128,7 @@ func defaultTestSetup(testDirPath string, knownAPIResources ...*metav1.APIResour
 		}).
 		WithDynamicObjectsWithStatus(platformClusterID, &clustersv1alpha1.AccessRequest{}).
 		WithReconcilerConstructor(pwcRec, func(c ...client.Client) reconcile.Reconciler {
-			pwc, err := sharedconfig.NewPWOConfigController(providerName, clusters.NewTestClusterFromClient(platformClusterID, c[0]), clusters.NewTestClusterFromClient(onboardingClusterID, c[1]), &commonapi.ObjectReference{Name: "onboarding", Namespace: "default"}, nil, podNamespace)
+			pwc, err := sharedconfig.NewPWOConfigController(providerName, clusters.NewTestClusterFromClient(platformClusterID, c[0]), clusters.NewTestClusterFromClient(onboardingClusterID, c[1]), &commonapi.ObjectReference{Name: "onboarding", Namespace: "default"}, nil, podNamespace, nil)
 			Expect(err).ToNot(HaveOccurred(), "failed to create PWOConfigController")
 			pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestReadiness, advanced.FakeAccessRequestReadiness())
 			pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestDeletion, advanced.FakeAccessRequestDeletion([]string{"clusterprovider"}, nil))
@@ -756,6 +759,116 @@ var _ = Describe("ProjectWorkspaceConfig Controller Test", func() {
 		delete(cfg.Spec.Workspace.AdditionalPermissions, pwov1alpha1.WorkspaceRoleView)
 		Expect(env.Client(platformClusterID).Update(env.Ctx, cfg)).To(Succeed())
 		originallyExpected.validate(env, pwc)
+	})
+
+	It("should update workspace ClusterRoles on the onboarding cluster when a ServiceProvider is added or removed", func() {
+		testDirPath := filepath.Join("testdata", "test-05")
+		fooAPIResources := &metav1.APIResourceList{
+			GroupVersion: "foo.services.openmcp.cloud/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "foos",
+					Group:      "foo.services.openmcp.cloud",
+					Version:    "v1alpha1",
+					Kind:       "Foo",
+					Namespaced: true,
+				},
+			},
+		}
+		knownAPIResources := []*metav1.APIResourceList{fooAPIResources}
+
+		// Build the environment with an RBACSetup wired in
+		envb := testutils.NewComplexEnvironmentBuilder().
+			WithFakeClient(platformClusterID, platformScheme).
+			WithFakeClient(onboardingClusterID, onboardingScheme)
+		platformDirPath := filepath.Join(testDirPath, "platform")
+		if pdi, err := os.Stat(platformDirPath); err == nil && pdi.IsDir() {
+			envb = envb.WithInitObjectPath(platformClusterID, platformDirPath)
+		}
+		env := envb.
+			WithInitObjects(platformClusterID, &clustersv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "onboarding",
+					Namespace: "default",
+				},
+			}).
+			WithDynamicObjectsWithStatus(platformClusterID, &clustersv1alpha1.AccessRequest{}).
+			WithReconcilerConstructor(pwcRec, func(c ...client.Client) reconcile.Reconciler {
+				onboardingClient := c[1]
+				rbacSetup := core.NewRBACSetup(logr.Discard(), onboardingClient, core.ControllerName, pwov1alpha1.ProjectWorkspaceConfigSpec{})
+
+				pwc, err := sharedconfig.NewPWOConfigController(providerName, clusters.NewTestClusterFromClient(platformClusterID, c[0]), clusters.NewTestClusterFromClient(onboardingClusterID, onboardingClient), &commonapi.ObjectReference{Name: "onboarding", Namespace: "default"}, nil, podNamespace, rbacSetup)
+				Expect(err).ToNot(HaveOccurred(), "failed to create PWOConfigController")
+				pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestReadiness, advanced.FakeAccessRequestReadiness())
+				pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestDeletion, advanced.FakeAccessRequestDeletion([]string{"clusterprovider"}, nil))
+				pwc.Car.WithFakeClientGenerator(func(ctx context.Context, kcfgData []byte, scheme *runtime.Scheme, additionalData ...any) (client.Client, error) {
+					return pwc.OnboardingClusterAccessStatic.Client(), nil
+				})
+				fd := fakeclientset.NewClientset().Discovery().(*fakediscovery.FakeDiscovery)
+				fd.Resources = knownAPIResources
+				for _, akrl := range alwaysKnownAPIResources {
+					found := false
+					for _, krl := range fd.Resources {
+						if krl.GroupVersion == akrl.GroupVersion {
+							krl.APIResources = append(krl.APIResources, akrl.APIResources...)
+							found = true
+							break
+						}
+					}
+					if !found {
+						fd.Resources = append(fd.Resources, akrl)
+					}
+				}
+				pwc.DiscoveryService = fd
+				return pwc
+			}, platformClusterID, onboardingClusterID).
+			Build()
+
+		req := testutils.RequestFromStrings(providerName)
+		EventuallyWithOffset(1, env.ShouldReconcile).WithArguments(pwcRec, req).Should(WithTransform(func(rr reconcile.Result) time.Duration { return rr.RequeueAfter }, BeZero()))
+
+		// After reconciliation, the workspace ClusterRoles on the onboarding cluster should contain
+		// the dynamic rules derived from the Foo ServiceProvider.
+		adminCR := &rbacv1.ClusterRole{}
+		err := env.Client(onboardingClusterID).Get(env.Ctx, types.NamespacedName{Name: "workspace-admin"}, adminCR)
+		Expect(err).ToNot(HaveOccurred(), "workspace-admin ClusterRole should exist on onboarding cluster")
+		Expect(adminCR.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"foo.services.openmcp.cloud"},
+			Resources: []string{"foos"},
+			Verbs:     []string{"*"},
+		}), "workspace-admin ClusterRole should contain dynamic Foo rule")
+
+		viewCR := &rbacv1.ClusterRole{}
+		err = env.Client(onboardingClusterID).Get(env.Ctx, types.NamespacedName{Name: "workspace-view"}, viewCR)
+		Expect(err).ToNot(HaveOccurred(), "workspace-view ClusterRole should exist on onboarding cluster")
+		Expect(viewCR.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"foo.services.openmcp.cloud"},
+			Resources: []string{"foos"},
+			Verbs:     []string{"get", "list", "watch"},
+		}), "workspace-view ClusterRole should contain dynamic Foo rule")
+
+		// Now delete the ServiceProvider and verify the rules are removed
+		sp := &providerv1alpha1.ServiceProvider{}
+		sp.Name = "foo"
+		Expect(env.Client(platformClusterID).Delete(env.Ctx, sp)).To(Succeed())
+
+		EventuallyWithOffset(1, env.ShouldReconcile).WithArguments(pwcRec, req).Should(WithTransform(func(rr reconcile.Result) time.Duration { return rr.RequeueAfter }, BeZero()))
+
+		err = env.Client(onboardingClusterID).Get(env.Ctx, types.NamespacedName{Name: "workspace-admin"}, adminCR)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(adminCR.Rules).ToNot(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"foo.services.openmcp.cloud"},
+			Resources: []string{"foos"},
+			Verbs:     []string{"*"},
+		}), "workspace-admin ClusterRole should no longer contain Foo rule after ServiceProvider deletion")
+
+		err = env.Client(onboardingClusterID).Get(env.Ctx, types.NamespacedName{Name: "workspace-view"}, viewCR)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(viewCR.Rules).ToNot(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"foo.services.openmcp.cloud"},
+			Resources: []string{"foos"},
+			Verbs:     []string{"get", "list", "watch"},
+		}), "workspace-view ClusterRole should no longer contain Foo rule after ServiceProvider deletion")
 	})
 
 })

--- a/internal/controller/config/testdata/test-05/platform/pwo-cfg.yaml
+++ b/internal/controller/config/testdata/test-05/platform/pwo-cfg.yaml
@@ -1,0 +1,5 @@
+apiVersion: core.openmcp.cloud/v1alpha1
+kind: ProjectWorkspaceConfig
+metadata:
+  name: project-workspace
+spec: {}

--- a/internal/controller/config/testdata/test-05/platform/sp-foo.yaml
+++ b/internal/controller/config/testdata/test-05/platform/sp-foo.yaml
@@ -1,0 +1,13 @@
+apiVersion: openmcp.cloud/v1alpha1
+kind: ServiceProvider
+metadata:
+  name: foo
+spec:
+  image: foo:latest
+status:
+  observedGeneration: 1
+  phase: Ready
+  resources:
+  - group: foo.services.openmcp.cloud
+    kind: Foo
+    version: v1alpha1

--- a/internal/controller/core/rbac.go
+++ b/internal/controller/core/rbac.go
@@ -114,15 +114,17 @@ func (setup *RBACSetup) CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx co
 			clusterRole.Rules = append(clusterRole.Rules, setup.config.Project.AdditionalPermissions[role]...)
 
 			// append dynamic rules derived from ServiceProviders
-			var roleID string
-			switch role {
-			case pwv1alpha1.ProjectRoleAdmin:
-				roleID = "admin"
-			case pwv1alpha1.ProjectRoleView:
-				roleID = "viewer"
-			}
-			if dynRules, ok := dynamicRules[roleID]; ok {
-				clusterRole.Rules = append(clusterRole.Rules, dynRules...)
+			if dynamicRules != nil {
+				var roleID string
+				switch role {
+				case pwv1alpha1.ProjectRoleAdmin:
+					roleID = "admin"
+				case pwv1alpha1.ProjectRoleView:
+					roleID = "viewer"
+				}
+				if dynRules, ok := dynamicRules[roleID]; ok {
+					clusterRole.Rules = append(clusterRole.Rules, dynRules...)
+				}
 			}
 
 			return nil

--- a/internal/controller/core/rbac.go
+++ b/internal/controller/core/rbac.go
@@ -60,6 +60,10 @@ func (setup *RBACSetup) EnsureResources(ctx context.Context) error {
 }
 
 func (setup *RBACSetup) createOrUpdateProjectClusterRoles(ctx context.Context) error {
+	return setup.CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx, nil)
+}
+
+func (setup *RBACSetup) CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx context.Context, dynamicRules map[string][]rbacv1.PolicyRule) error {
 	projectRoles := map[pwv1alpha1.ProjectMemberRole][]string{
 		pwv1alpha1.ProjectRoleAdmin: AllVerbs,
 		pwv1alpha1.ProjectRoleView:  ReadOnlyVerbs,
@@ -109,6 +113,18 @@ func (setup *RBACSetup) createOrUpdateProjectClusterRoles(ctx context.Context) e
 			// add roles from config, if defined
 			clusterRole.Rules = append(clusterRole.Rules, setup.config.Project.AdditionalPermissions[role]...)
 
+			// append dynamic rules derived from ServiceProviders
+			var roleID string
+			switch role {
+			case pwv1alpha1.ProjectRoleAdmin:
+				roleID = "admin"
+			case pwv1alpha1.ProjectRoleView:
+				roleID = "viewer"
+			}
+			if dynRules, ok := dynamicRules[roleID]; ok {
+				clusterRole.Rules = append(clusterRole.Rules, dynRules...)
+			}
+
 			return nil
 		})
 		if err != nil {
@@ -121,6 +137,10 @@ func (setup *RBACSetup) createOrUpdateProjectClusterRoles(ctx context.Context) e
 }
 
 func (setup *RBACSetup) createOrUpdateWorkspaceClusterRoles(ctx context.Context) error {
+	return setup.CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx, nil)
+}
+
+func (setup *RBACSetup) CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx context.Context, dynamicRules map[string][]rbacv1.PolicyRule) error {
 	workspaceRoles := map[pwv1alpha1.WorkspaceMemberRole][]string{
 		pwv1alpha1.WorkspaceRoleAdmin: AllVerbs,
 		pwv1alpha1.WorkspaceRoleView:  ReadOnlyVerbs,
@@ -173,6 +193,18 @@ func (setup *RBACSetup) createOrUpdateWorkspaceClusterRoles(ctx context.Context)
 
 			// add roles from config, if defined
 			clusterRole.Rules = append(clusterRole.Rules, setup.config.Workspace.AdditionalPermissions[role]...)
+
+			// append dynamic rules derived from ServiceProviders
+			var roleID string
+			switch role {
+			case pwv1alpha1.WorkspaceRoleAdmin:
+				roleID = "admin"
+			case pwv1alpha1.WorkspaceRoleView:
+				roleID = "viewer"
+			}
+			if dynRules, ok := dynamicRules[roleID]; ok {
+				clusterRole.Rules = append(clusterRole.Rules, dynRules...)
+			}
 
 			return nil
 		})

--- a/internal/controller/core/rbac_test.go
+++ b/internal/controller/core/rbac_test.go
@@ -201,3 +201,135 @@ func TestRBACSetup_EnsureResources(t *testing.T) {
 		})
 	}
 }
+
+func TestRBACSetup_CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(t *testing.T) {
+	ctx := context.TODO()
+	c := fake.NewClientBuilder().Build()
+	s := NewRBACSetup(testr.New(t), c, "test-rbac-controller", pwv1alpha1.ProjectWorkspaceConfigSpec{})
+
+	dynamicRules := map[string][]rbacv1.PolicyRule{
+		"admin": {
+			{
+				APIGroups: []string{"foo.services.openmcp.cloud"},
+				Resources: []string{"foos"},
+				Verbs:     []string{"*"},
+			},
+		},
+		"viewer": {
+			{
+				APIGroups: []string{"foo.services.openmcp.cloud"},
+				Resources: []string{"foos"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+
+	err := s.CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx, dynamicRules)
+	assert.NoError(t, err)
+
+	// Verify admin ClusterRole contains the dynamic rule
+	adminCR := &rbacv1.ClusterRole{}
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.WorkspaceRoleAdmin)}, adminCR)
+	assert.NoError(t, err)
+	assert.Contains(t, adminCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"foo.services.openmcp.cloud"},
+		Resources: []string{"foos"},
+		Verbs:     []string{"*"},
+	})
+
+	// Verify viewer ClusterRole contains the dynamic rule
+	viewerCR := &rbacv1.ClusterRole{}
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.WorkspaceRoleView)}, viewerCR)
+	assert.NoError(t, err)
+	assert.Contains(t, viewerCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"foo.services.openmcp.cloud"},
+		Resources: []string{"foos"},
+		Verbs:     []string{"get", "list", "watch"},
+	})
+
+	// Verify that calling with nil dynamic rules removes the dynamic rules
+	err = s.CreateOrUpdateWorkspaceClusterRolesWithDynamicRules(ctx, nil)
+	assert.NoError(t, err)
+
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.WorkspaceRoleAdmin)}, adminCR)
+	assert.NoError(t, err)
+	assert.NotContains(t, adminCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"foo.services.openmcp.cloud"},
+		Resources: []string{"foos"},
+		Verbs:     []string{"*"},
+	})
+
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.WorkspaceRoleView)}, viewerCR)
+	assert.NoError(t, err)
+	assert.NotContains(t, viewerCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"foo.services.openmcp.cloud"},
+		Resources: []string{"foos"},
+		Verbs:     []string{"get", "list", "watch"},
+	})
+}
+
+func TestRBACSetup_CreateOrUpdateProjectClusterRolesWithDynamicRules(t *testing.T) {
+	ctx := context.TODO()
+	c := fake.NewClientBuilder().Build()
+	s := NewRBACSetup(testr.New(t), c, "test-rbac-controller", pwv1alpha1.ProjectWorkspaceConfigSpec{})
+
+	dynamicRules := map[string][]rbacv1.PolicyRule{
+		"admin": {
+			{
+				APIGroups: []string{"custom.example.com"},
+				Resources: []string{"myresources"},
+				Verbs:     []string{"*"},
+			},
+		},
+		"viewer": {
+			{
+				APIGroups: []string{"custom.example.com"},
+				Resources: []string{"myresources"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+
+	err := s.CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx, dynamicRules)
+	assert.NoError(t, err)
+
+	// Verify admin ClusterRole contains the dynamic rule
+	adminCR := &rbacv1.ClusterRole{}
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.ProjectRoleAdmin)}, adminCR)
+	assert.NoError(t, err)
+	assert.Contains(t, adminCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"custom.example.com"},
+		Resources: []string{"myresources"},
+		Verbs:     []string{"*"},
+	})
+
+	// Verify viewer ClusterRole contains the dynamic rule
+	viewerCR := &rbacv1.ClusterRole{}
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.ProjectRoleView)}, viewerCR)
+	assert.NoError(t, err)
+	assert.Contains(t, viewerCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"custom.example.com"},
+		Resources: []string{"myresources"},
+		Verbs:     []string{"get", "list", "watch"},
+	})
+
+	// Verify that calling with nil dynamic rules removes the dynamic rules
+	err = s.CreateOrUpdateProjectClusterRolesWithDynamicRules(ctx, nil)
+	assert.NoError(t, err)
+
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.ProjectRoleAdmin)}, adminCR)
+	assert.NoError(t, err)
+	assert.NotContains(t, adminCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"custom.example.com"},
+		Resources: []string{"myresources"},
+		Verbs:     []string{"*"},
+	})
+
+	err = c.Get(ctx, types.NamespacedName{Name: clusterRoleForRole(pwv1alpha1.ProjectRoleView)}, viewerCR)
+	assert.NoError(t, err)
+	assert.NotContains(t, viewerCR.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"custom.example.com"},
+		Resources: []string{"myresources"},
+		Verbs:     []string{"get", "list", "watch"},
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the missing update on the PWO clusterroles one the onboarding cluster that are being used to grant user access to service provider resources.
The access tho these resources is dynamically calcualted based on the installed service providers on the platform cluster.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This change uses the same config reconiler since it is already used to update the PWO access request for resources blocking deletion.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Add dynamic update of PWO project/workspace clusterroles on the onboarding cluster 
```
