### PR TITLE
make projects and workspaces respect the operation annotation

### DIFF
--- a/cmd/platform-service-project-workspace/app/run.go
+++ b/cmd/platform-service-project-workspace/app/run.go
@@ -314,7 +314,7 @@ func (o *RunOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("unable to get cluster request for onboarding cluster: %w", err)
 	}
 
-	cfgCtrl, err := sharedconfig.NewPWOConfigController(o.ProviderName, o.PlatformCluster, onboardingCluster, cr.Status.Cluster, nil, podNamespace)
+	cfgCtrl, err := sharedconfig.NewPWConfigController(o.ProviderName, o.PlatformCluster, onboardingCluster, cr.Status.Cluster, nil, podNamespace)
 	if err != nil {
 		return fmt.Errorf("unable to create ProjectWorkspaceConfig controller: %w", err)
 	}

--- a/internal/controller/config/controller.go
+++ b/internal/controller/config/controller.go
@@ -68,14 +68,14 @@ type PWOConfigController struct {
 	missingConfig                  bool
 }
 
-// NewPWOConfigController creates a new PWOConfigController.
+// NewPWConfigController creates a new PWOConfigController.
 // This controller has the following responsibilities:
 // - It watches the ProjectWorkspaceConfig resource belonging to this instance of the PlatformService PWO and reloads it on changes.
 // - It watches ServiceProvider resources for their registered resource types in their status and updates permissions and blocking resources accordingly.
 // - It can trigger project and workspace reconciliations via the passed-in channels if the config changes in a way that requires it.
 // - It implements the SharedInformation interface, so that other controllers can query it for the current configuration.
 // - It reconciles the OnboardingCluster AccessRequests for the project and workspace controllers to ensure they can always fetch the the resources that are supposed to block deletion.
-func NewPWOConfigController(providerName string, platformCluster *clusters.Cluster, onboardingClusterStatic *clusters.Cluster, onboardingClusterRef *commonapi.ObjectReference, rec record.EventRecorder, podNamespace string) (*PWOConfigController, error) {
+func NewPWConfigController(providerName string, platformCluster *clusters.Cluster, onboardingClusterStatic *clusters.Cluster, onboardingClusterRef *commonapi.ObjectReference, rec record.EventRecorder, podNamespace string) (*PWOConfigController, error) {
 	scheme := install.InstallOperatorAPIsOnboarding(runtime.NewScheme())
 	obRef := advanced.StaticReferenceGenerator(onboardingClusterRef)
 	var ds discovery.DiscoveryInterface

--- a/internal/controller/config/controller_test.go
+++ b/internal/controller/config/controller_test.go
@@ -125,7 +125,7 @@ func defaultTestSetup(testDirPath string, knownAPIResources ...*metav1.APIResour
 		}).
 		WithDynamicObjectsWithStatus(platformClusterID, &clustersv1alpha1.AccessRequest{}).
 		WithReconcilerConstructor(pwcRec, func(c ...client.Client) reconcile.Reconciler {
-			pwc, err := sharedconfig.NewPWOConfigController(providerName, clusters.NewTestClusterFromClient(platformClusterID, c[0]), clusters.NewTestClusterFromClient(onboardingClusterID, c[1]), &commonapi.ObjectReference{Name: "onboarding", Namespace: "default"}, nil, podNamespace)
+			pwc, err := sharedconfig.NewPWConfigController(providerName, clusters.NewTestClusterFromClient(platformClusterID, c[0]), clusters.NewTestClusterFromClient(onboardingClusterID, c[1]), &commonapi.ObjectReference{Name: "onboarding", Namespace: "default"}, nil, podNamespace)
 			Expect(err).ToNot(HaveOccurred(), "failed to create PWOConfigController")
 			pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestReadiness, advanced.FakeAccessRequestReadiness())
 			pwc.Car.WithFakingCallback(advanced.FakingCallback_WaitingForAccessRequestDeletion, advanced.FakeAccessRequestDeletion([]string{"clusterprovider"}, nil))

--- a/internal/controller/core/project_controller.go
+++ b/internal/controller/core/project_controller.go
@@ -11,11 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	ctrlutils "github.com/openmcp-project/controller-utils/pkg/controller"
 	"github.com/openmcp-project/controller-utils/pkg/logging"
+	apiconst "github.com/openmcp-project/openmcp-operator/api/constants"
 
 	pwv1alpha1 "github.com/openmcp-project/platform-service-project-workspace/api/v2/core/v1alpha1"
 	"github.com/openmcp-project/platform-service-project-workspace/internal/utils"
@@ -79,6 +83,23 @@ func (r *ProjectReconciler) reconcile(ctx context.Context, req ctrl.Request) (ct
 			return sr.StopRequeue()
 		}
 		return sr.ReturnError(fmt.Errorf("error fetching project: %w", err))
+	}
+
+	// handle operation annotation
+	if project.GetAnnotations() != nil {
+		op, ok := project.GetAnnotations()[apiconst.OperationAnnotation]
+		if ok {
+			switch op {
+			case apiconst.OperationAnnotationValueIgnore:
+				log.Info("Ignoring resource due to ignore operation annotation")
+				return sr.StopRequeue()
+			case apiconst.OperationAnnotationValueReconcile:
+				log.Debug("Removing reconcile operation annotation from resource")
+				if err := ctrlutils.EnsureAnnotation(ctx, r.OnboardingStatic.Client(), project, apiconst.OperationAnnotation, "", true, ctrlutils.DELETE); err != nil {
+					return sr.ReturnError(fmt.Errorf("error removing operation annotation: %w", err))
+				}
+			}
+		}
 	}
 
 	projectNamespace := &corev1.Namespace{
@@ -168,7 +189,19 @@ func (r *ProjectReconciler) reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *ProjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&pwv1alpha1.Project{}).
+		For(&pwv1alpha1.Project{}, builder.WithPredicates(
+			predicate.And(
+				predicate.Or(
+					predicate.GenerationChangedPredicate{},
+					ctrlutils.DeletionTimestampChangedPredicate{},
+					ctrlutils.GotAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueReconcile),
+					ctrlutils.LostAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueIgnore),
+				),
+				predicate.Not(
+					ctrlutils.HasAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueIgnore),
+				),
+			),
+		)).
 		Complete(r)
 }
 

--- a/internal/controller/core/workspace_controller.go
+++ b/internal/controller/core/workspace_controller.go
@@ -13,11 +13,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	ctrlutils "github.com/openmcp-project/controller-utils/pkg/controller"
 	"github.com/openmcp-project/controller-utils/pkg/logging"
+	apiconst "github.com/openmcp-project/openmcp-operator/api/constants"
 
 	pwv1alpha1 "github.com/openmcp-project/platform-service-project-workspace/api/v2/core/v1alpha1"
 	"github.com/openmcp-project/platform-service-project-workspace/internal/utils"
@@ -85,6 +89,23 @@ func (r *WorkspaceReconciler) reconcile(ctx context.Context, req ctrl.Request) (
 			return sr.StopRequeue()
 		}
 		return sr.ReturnError(fmt.Errorf("error fetching workspace: %w", err))
+	}
+
+	// handle operation annotation
+	if workspace.GetAnnotations() != nil {
+		op, ok := workspace.GetAnnotations()[apiconst.OperationAnnotation]
+		if ok {
+			switch op {
+			case apiconst.OperationAnnotationValueIgnore:
+				log.Info("Ignoring resource due to ignore operation annotation")
+				return sr.StopRequeue()
+			case apiconst.OperationAnnotationValueReconcile:
+				log.Debug("Removing reconcile operation annotation from resource")
+				if err := ctrlutils.EnsureAnnotation(ctx, r.OnboardingStatic.Client(), workspace, apiconst.OperationAnnotation, "", true, ctrlutils.DELETE); err != nil {
+					return sr.ReturnError(fmt.Errorf("error removing operation annotation: %w", err))
+				}
+			}
+		}
 	}
 
 	project, err := r.getProjectByNamespace(ctx, workspace.Namespace)
@@ -339,7 +360,19 @@ func (r *WorkspaceReconciler) deleteClusterRole(ctx context.Context, project *pw
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&pwv1alpha1.Workspace{}).
+		For(&pwv1alpha1.Workspace{}, builder.WithPredicates(
+			predicate.And(
+				predicate.Or(
+					predicate.GenerationChangedPredicate{},
+					ctrlutils.DeletionTimestampChangedPredicate{},
+					ctrlutils.GotAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueReconcile),
+					ctrlutils.LostAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueIgnore),
+				),
+				predicate.Not(
+					ctrlutils.HasAnnotationPredicate(apiconst.OperationAnnotation, apiconst.OperationAnnotationValueIgnore),
+				),
+			),
+		)).
 		Complete(r)
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -39,12 +39,12 @@ func SetMetaDataLabel(meta metav1.Object, key, value string) {
 	meta.SetLabels(labels)
 }
 
-func LogOperationResult(log logging.Logger, level logging.LogLevel, obj client.Object, result controllerutil.OperationResult) {
+func LogOperationResult(log logging.Logger, level logging.LogLevel, obj client.Object, result controllerutil.OperationResult, additionalKeysAndValues ...any) {
 	objType := reflect.ValueOf(obj).Elem().Type()
 	if obj.GetNamespace() == "" {
-		log.Log(level, fmt.Sprintf("%s %s %s", objType.Name(), obj.GetName(), result))
+		log.Log(level, fmt.Sprintf("%s %s %s", objType.Name(), obj.GetName(), result), additionalKeysAndValues...)
 	} else {
-		log.Log(level, fmt.Sprintf("%s %s/%s %s", objType.Name(), obj.GetNamespace(), obj.GetName(), result))
+		log.Log(level, fmt.Sprintf("%s %s/%s %s", objType.Name(), obj.GetNamespace(), obj.GetName(), result), additionalKeysAndValues...)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the `openmcp.cloud/operation` annotation work on Projects and Workspaces.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `openmcp.cloud/operation` annotation can now be used on `Project` and `Workspace` resources.
```
